### PR TITLE
57 UI för uppdater användarens profil

### DIFF
--- a/pegasus-frontend/src/components/customer/ProfileSettings.vue
+++ b/pegasus-frontend/src/components/customer/ProfileSettings.vue
@@ -6,12 +6,14 @@ import { useToast } from "vue-toastification";
 import useFormValidation, {
   type DefaultField,
 } from "@/hooks/useFormValidation";
-import { ref } from "vue";
+import { onMounted, ref, watch } from "vue";
 import type { UpdateUserRequestDto } from "@/types/update-user-request-dto";
 import { userApi } from "@/endpoints/user";
+import type { UserResponseDto } from "@/types/user-response-dto";
 
 const toast = useToast();
 const isLoading = ref(false);
+const userDetails = ref<UserResponseDto | null>(null);
 
 const {
   createDefaultField,
@@ -26,6 +28,29 @@ const firstName = ref<DefaultField>(createDefaultField());
 const lastName = ref<DefaultField>(createDefaultField());
 const email = ref<DefaultField>(createDefaultField());
 const phoneNumber = ref<DefaultField>(createDefaultField());
+
+const populateFormFields = (user: UserResponseDto) => {
+  username.value = createDefaultField();
+  username.value.value = user.userName || "";
+  firstName.value = createDefaultField();
+  firstName.value.value = user.firstName || "";
+  lastName.value = createDefaultField();
+  lastName.value.value = user.lastName || "";
+  email.value = createDefaultField();
+  email.value.value = user.email || "";
+  phoneNumber.value = createDefaultField();
+  phoneNumber.value.value = user.phoneNumber || "";
+};
+
+watch(
+  userDetails,
+  (newUserDetails) => {
+    if (newUserDetails) {
+      populateFormFields(newUserDetails);
+    }
+  },
+  { immediate: true }
+);
 
 const validateUsernameField = () => validateField(username.value, "Username");
 const validateFirstNameField = () =>
@@ -64,6 +89,17 @@ const updateProfile = async () => {
     isLoading.value = false;
   }
 };
+
+const getUser = async () => {
+  try {
+    const response = await userApi.getUserProfile();
+    userDetails.value = response.data;
+    console.log(userDetails.value);
+  } catch (err) {
+    toast.error("Error fetching user details");
+  }
+};
+onMounted(() => getUser());
 </script>
 
 <template>

--- a/pegasus-frontend/src/endpoints/user.ts
+++ b/pegasus-frontend/src/endpoints/user.ts
@@ -2,14 +2,21 @@ import api from "@/plugins/axios";
 import type { ApiResponse } from "@/types/api-response-dto";
 import type { UpdateUserRequestDto } from "@/types/update-user-request-dto";
 import type { UpdateUserResponseDto } from "@/types/update-user-response-dto";
+import type { UserResponseDto } from "@/types/user-response-dto";
 
 export const userApi = {
   async updateProfile(
     data: UpdateUserRequestDto
   ): Promise<ApiResponse<UpdateUserResponseDto>> {
-    const response = await api.post<ApiResponse<UpdateUserResponseDto>>(
+    const response = await api.put<ApiResponse<UpdateUserResponseDto>>(
       "/api/User/UpdateUser",
       data
+    );
+    return response.data;
+  },
+  async getUserProfile(): Promise<ApiResponse<UserResponseDto>> {
+    const response = await api.get<ApiResponse<UserResponseDto>>(
+      "/api/User/GetLoggedInUserData"
     );
     return response.data;
   },

--- a/pegasus-frontend/src/types/user-response-dto.ts
+++ b/pegasus-frontend/src/types/user-response-dto.ts
@@ -9,4 +9,5 @@ export interface UserResponseDto {
     firstName: string;
     lastName: string;
     email: string;
+    phoneNumber: string;
 }


### PR DESCRIPTION
This pull request enhances the customer profile settings in the frontend by introducing functionality to fetch and display the currently logged-in user's details. The changes include adding a new API endpoint for retrieving user data, updating the form population logic, and extending the user data type.

**User profile data fetching and form population:**

* Added a new `getUserProfile` method to `userApi` in `user.ts` to retrieve the logged-in user's details from the backend (`/api/User/GetLoggedInUserData`).
* Introduced a `userDetails` ref and a `getUser` function in `ProfileSettings.vue` to fetch user data on component mount and store it locally. [[1]](diffhunk://#diff-d0fabc2f49c8a7761d707d4596ed9d9e8db636706ad17aa4c6cab3ecf6cc8c6eL9-R16) [[2]](diffhunk://#diff-d0fabc2f49c8a7761d707d4596ed9d9e8db636706ad17aa4c6cab3ecf6cc8c6eR92-R102)
* Implemented a `populateFormFields` function and a watcher on `userDetails` to automatically fill form fields with the fetched user data.

**Type and API updates:**

* Extended the `UserResponseDto` type to include a `phoneNumber` property, ensuring all relevant user information is handled.
* Changed the `updateProfile` API method to use HTTP PUT instead of POST for updating user data, aligning with REST conventions.